### PR TITLE
Add support for FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This Ansible role allows you to deploy and configure multiple Tor Bridge nodes.
 
-Currently this role is only supported on Debian. In future improvements we will support other distributions.
+Currently this role is only supported on Debian and FreeBSD. In future improvements we will support other distributions.
 
 ## Installation
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-# defaults file for bridge
+bridge_line_file: /tmp/bridge.txt

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,10 @@ galaxy_info:
     - name: Debian
       versions:
         - all
+    - name: FreeBSD
+      versions:
+        - 12.2
+        - 13.0
   galaxy_tags:
     - tor
     - tor-bridges

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,22 @@
 ---
 # tasks file for bridge
+- name: Set OS specific variables
+  include_vars: "os_{{ ansible_os_family }}.yml"
+  tags:
+    - always
 - import_tasks: system_packages.yml
+  when: ansible_os_family == 'Debian'
+- import_tasks: system_packages_freebsd.yml
+  when: ansible_os_family == 'FreeBSD'
 - import_tasks: update_config.yml
+  when: ansible_os_family == 'Debian'
 - import_tasks: tor_packages.yml
+  when: ansible_os_family == 'Debian'
+- import_tasks: tor_packages_freebsd.yml
+  when: ansible_os_family == 'FreeBSD'
 - import_tasks: tor_config.yml
 - import_tasks: service.yml
+  when: ansible_os_family == 'Debian'
+- import_tasks: service_freebsd.yml
+  when: ansible_os_family == 'FreeBSD'
 - import_tasks: bridge_line.yml

--- a/tasks/service_freebsd.yml
+++ b/tasks/service_freebsd.yml
@@ -1,0 +1,44 @@
+- name: Enable set Tor uid
+  community.general.sysrc:
+    name: tor_uid
+    value: "YES"
+    state: present
+  tags:
+    - enable
+    - install_all
+
+- name: Enable Tor
+  community.general.sysrc:
+    name: tor_enable
+    value: "YES"
+    state: present
+  tags:
+    - enable
+    - install_all
+
+- name: Restart Tor service
+  service:
+    name: tor
+    state: restarted
+  tags:
+    - restart
+    - install_all
+
+- name: Reload Tor service
+  service:
+    name: tor
+    state: reloaded
+  tags:
+    - reload
+
+- name: Stop Tor service
+  service:
+    name: tor
+    state: stopped
+  tags:
+    - stop
+
+- name: Start Tor service
+  service:
+    name: tor
+    state: started

--- a/tasks/system_packages_freebsd.yml
+++ b/tasks/system_packages_freebsd.yml
@@ -1,0 +1,23 @@
+- name: Ensure FreeBSD conf directory exists
+  file:
+    path: /usr/local/etc/pkg/repos
+    state: directory
+  tags:
+    - install_all
+
+- name: Configure FreeBSD to use HTTPS
+  copy:
+    content: |
+      FreeBSD: {
+        url: pkg+https://pkg.freebsd.org/${ABI}/latest
+      }
+    dest: /usr/local/etc/pkg/repos/FreeBSD.conf
+  tags:
+    - install_all
+
+- name: Packages installation (FreeBSD)
+  pkgng:
+    name: "{{ system_packages }}"
+    state: latest
+  tags:
+    - install_all

--- a/tasks/tor_config.yml
+++ b/tasks/tor_config.yml
@@ -1,11 +1,17 @@
 - name: Configure Torrc file
   template:
     src: torrc.j2
-    dest: "/etc/tor/torrc"
+    dest: "{{ torrc_path }}"
     owner: "root"
-    group: "root"
+    group: "{{ torrc_group }}"
     mode: 0644
   tags:
     - tor_config
     - install_all
 
+- name: Configure net.inet.ip.random_id
+  ansible.posix.sysctl:
+    name: net.inet.ip.random_id
+    value: "1"
+    state: present
+  when: ansible_os_family == 'FreeBSD'

--- a/tasks/tor_packages_freebsd.yml
+++ b/tasks/tor_packages_freebsd.yml
@@ -1,0 +1,7 @@
+- name: Install Tor packages
+  pkgng:
+    name: "{{ tor_packages }}"
+    state: latest
+  tags:
+    - tor_packages
+    - install_all

--- a/templates/torrc.j2
+++ b/templates/torrc.j2
@@ -2,7 +2,7 @@ BridgeRelay 1
 
 ORPort {{ tor_port }}
 
-ServerTransportPlugin obfs4 exec /usr/bin/obfs4proxy
+ServerTransportPlugin obfs4 exec {{ obfs4_path }}
 
 ServerTransportListenAddr obfs4 0.0.0.0:{{ obfs4_port }}
 

--- a/vars/os_Debian.yml
+++ b/vars/os_Debian.yml
@@ -1,16 +1,17 @@
 ---
-# vars file for bridge
-
 system_packages:
   - unattended-upgrades
   - apt-listchanges
   - apt-transport-https
 
 tor_packages:
-  - tor 
+  - tor
   - deb.torproject.org-keyring
   - obfs4proxy
 
+torrc_path: /etc/tor/torrc
+torrc_group: root
+obfs4_path: /usr/bin/obfs4proxy
+
 fingerprint_file: /var/lib/tor/fingerprint
 cert_file: /var/lib/tor/pt_state/obfs4_bridgeline.txt
-bridge_line_file: /tmp/bridge.txt

--- a/vars/os_FreeBSD.yml
+++ b/vars/os_FreeBSD.yml
@@ -1,0 +1,14 @@
+---
+system_packages:
+  - ca_root_nss
+
+tor_packages:
+  - tor
+  - obfs4proxy-tor
+
+torrc_path: /usr/local/etc/tor/torrc
+torrc_group: wheel
+obfs4_path: /usr/local/bin/obfs4proxy
+
+fingerprint_file: /var/db/tor/fingerprint
+cert_file: /var/db/tor/pt_state/obfs4_bridgeline.txt


### PR DESCRIPTION
Related to #1, adds support for FreeBSD. One of the main changes I made is splitting out OS-specific variables files and loading them with `include_vars`, and I based that on [nusenu/ansible-relayor](https://github.com/nusenu/ansible-relayor/blob/87ffdd9f80229232338aca57ab0711524e2d6e7c/tasks/main.yml#L65-L68). I tested this on FreeBSD 12.2 and 13.0 which is why I included those versions in `meta.yml`.

While going through the [FreeBSD instructions](https://community.torproject.org/relay/setup/bridge/freebsd/) it mentioned including the line "Log notice file" in `torrc`. Do you think it would make sense to update that here or make it configurable?

I'm happy to make any changes, thanks!