### PR TITLE
Add support for OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This Ansible role allows you to deploy and configure multiple Tor Bridge nodes.
 
-Currently this role is only supported on Debian and FreeBSD. In future improvements we will support other distributions.
+Currently this role is only supported on Debian, FreeBSD, and OpenBSD. In future improvements we will support other distributions.
 
 ## Installation
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,9 @@ galaxy_info:
       versions:
         - 12.2
         - 13.0
+    - name: OpenBSD
+      versions:
+        - 6.9
   galaxy_tags:
     - tor
     - tor-bridges

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,15 +8,21 @@
   when: ansible_os_family == 'Debian'
 - import_tasks: system_packages_freebsd.yml
   when: ansible_os_family == 'FreeBSD'
+- import_tasks: system_packages_openbsd.yml
+  when: ansible_os_family == 'OpenBSD'
 - import_tasks: update_config.yml
   when: ansible_os_family == 'Debian'
 - import_tasks: tor_packages.yml
   when: ansible_os_family == 'Debian'
 - import_tasks: tor_packages_freebsd.yml
   when: ansible_os_family == 'FreeBSD'
+- import_tasks: tor_packages_openbsd.yml
+  when: ansible_os_family == 'OpenBSD'
 - import_tasks: tor_config.yml
 - import_tasks: service.yml
   when: ansible_os_family == 'Debian'
 - import_tasks: service_freebsd.yml
   when: ansible_os_family == 'FreeBSD'
+- import_tasks: service_openbsd.yml
+  when: ansible_os_family == 'OpenBSD'
 - import_tasks: bridge_line.yml

--- a/tasks/service_openbsd.yml
+++ b/tasks/service_openbsd.yml
@@ -1,0 +1,12 @@
+- name: Enable Tor service
+  service:
+    name: tor
+    enabled: yes
+  tags:
+    - enable
+    - install_all
+
+- name: Start Tor service
+  service:
+    name: tor
+    state: started

--- a/tasks/system_packages_openbsd.yml
+++ b/tasks/system_packages_openbsd.yml
@@ -1,0 +1,10 @@
+- name: Install M:Tier openup
+  get_url:
+    url: https://stable.mtier.org/openup
+    dest: /usr/local/bin/openup
+    mode: 0755
+  tags:
+    - install_all
+
+- name: Run openup
+  shell: "/usr/local/bin/openup -N"

--- a/tasks/tor_config.yml
+++ b/tasks/tor_config.yml
@@ -15,3 +15,19 @@
     value: "1"
     state: present
   when: ansible_os_family == 'FreeBSD'
+
+- name: Configure kern.maxfiles
+  ansible.posix.sysctl:
+    name: kern.maxfiles
+    value: 16000
+    state: present
+  when: ansible_os_family == 'OpenBSD'
+
+- name: Add configuration to login.conf
+  blockinfile:
+    path: /etc/login.conf
+    block: |
+      tor:\
+        :openfiles-max=13500:\
+        :tc=daemon:
+  when: ansible_os_family == 'OpenBSD'

--- a/tasks/tor_packages_openbsd.yml
+++ b/tasks/tor_packages_openbsd.yml
@@ -1,0 +1,7 @@
+- name: Install Tor packages
+  openbsd_pkg:
+    name: "{{ tor_packages }}"
+    state: latest
+  tags:
+    - tor_packages
+    - install_all

--- a/vars/os_OpenBSD.yml
+++ b/vars/os_OpenBSD.yml
@@ -1,0 +1,13 @@
+---
+system_packages: []
+
+tor_packages:
+  - tor
+  - obfs4proxy
+
+torrc_path: /etc/tor/torrc
+torrc_group: wheel
+obfs4_path: /usr/local/bin/obfs4proxy
+
+fingerprint_file: "{{ ansible_env.HOME }}/.tor/fingerprint"
+cert_file: "{{ ansible_env.HOME }}/.tor/pt_state/obfs4_bridgeline.txt"


### PR DESCRIPTION
Adds OpenBSD support similar to #2. Tested on a Vultr VM with OpenBSD 6.9.

The main difference is I ran into some trouble with timeouts on the service step, so it doesn't include all of the tag actions and sometimes you're required to run it twice for the started state to set. Let me know if that works, thanks!